### PR TITLE
Allow custom user models

### DIFF
--- a/blacklist/models.py
+++ b/blacklist/models.py
@@ -1,6 +1,7 @@
 import ipaddress
 from datetime import timedelta
 
+from django.contrib.auth import get_user_model
 from django.db import models
 from django.core import validators
 from django.utils.timezone import now
@@ -12,7 +13,7 @@ class Rule(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
 
-    user = models.ForeignKey(User, null=True, blank=True, on_delete=models.CASCADE)
+    user = models.ForeignKey(get_user_model(), null=True, blank=True, on_delete=models.CASCADE)
 
     address = models.GenericIPAddressField(null=True, blank=True)
     prefixlen = models.PositiveIntegerField(null=True, blank=True,


### PR DESCRIPTION
Fixes https://github.com/vsemionov/django-blacklist/issues/1

```
SystemCheckError: System check identified some issues:

ERRORS:
blacklist.Rule.user: (fields.E301) Field defines a relation with the model 'auth.User', which has been swapped out.
        HINT: Update the relation to point at 'settings.AUTH_USER_MODEL'.
```